### PR TITLE
Redirect from StakeholderCommitteeInfo to the correct stakeholder page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@ email: lboeman@email.arizona.edu
 description: >- # this means to ignore newlines until "baseurl:"
   Solar Forecast Arbiter project site.
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "solararbiter.org" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://solarforecastarbiter.org" # the base hostname & protocol for your site, e.g. http://example.com
 github_username:  SolarArbiter
 
 # Build settings

--- a/_config.yml
+++ b/_config.yml
@@ -27,6 +27,7 @@ theme: minima
 plugins:
   - jekyll-feed
   - jekyll-paginate
+  - jekyll-redirect-from
 paginate: 5
 paginate_path: "/blog/page:num/"
 # custom vars

--- a/stakeholdercommittee.md
+++ b/stakeholdercommittee.md
@@ -1,6 +1,7 @@
 ---
 layout: base
 permalink: /stakeholdercommittee/
+redirect_from: "/StakeHolderCommitteeInfo/"
 ---
 
 # Stakeholder Committee


### PR DESCRIPTION
Redirects correctly from https://lboeman.github.io/StakeHolderCommitteeInfo to https://solarforecastarbiter.org/stakeholdercommittee 