### PR TITLE
documentation updates

### DIFF
--- a/dashboard_documentation.md
+++ b/dashboard_documentation.md
@@ -19,6 +19,7 @@ on how to access the current version of the dashboard.
 Please see the [data model documentation](/datamodel/) for more details on
 how the Solar Forecast Arbiter organizes metadata (Sites, Observations, and Forecasts)
 and time series data.
+Tutorial materials are available at this [link](https://github.com/SolarArbiter/2019-Denver-Workshop).
 
 
 Getting Started

--- a/dashboard_documentation.md
+++ b/dashboard_documentation.md
@@ -29,7 +29,7 @@ dashboard at [dashboard.solarforecastarbiter.org](https://dashboard.solarforecas
 |Email                                 | Password          |
 |--------------------------------------|-------------------|
 |testing@solarforecastarbiter.org      |Thepassword123!    |
-|utilityx@solarforecastarbiter.org     |Utilitypassword!   |   
+|utilityx@solarforecastarbiter.org     |Utilitypassword!   |
 |forecastera@solarforecastarbiter.org  |Forecasterpassword!|
 |forecasterb@solarforecastarbiter.org  |Forecasterpassword!|
 
@@ -45,10 +45,10 @@ Create New Site
    sidebar. At the top of the Site listing click ‘Create new Site’.
 <img class="my-3" src="/images/SitesListing.png"/>
 
-2. Enter the metadata for your Site. Selecting a site type of 
-   'Power Plant' will prompt you for additional fields. 
+2. Enter the metadata for your Site. Selecting a site type of
+   'Power Plant' will prompt you for additional fields.
 
-   
+
    - *Weather station site creation form*
    <img class="my-3" src="/images/SiteForm.png"/>
 
@@ -71,7 +71,7 @@ Create New Observation or Forecast
 To create an Observation or Forecast, an associated site must already exist (see [Create New Site](#create-new-site)).
 
 ### Create New Observation
-{: .anchor} 
+{: .anchor}
 
 1.  Navigate to the Site listing page using the ‘Sites’ link in the left
 	sidebar. Select the site for which you are adding an Observation.
@@ -206,9 +206,9 @@ for details.
     Add pairs of Observations and Forecasts to compare by clicking the 'Add
     Forecast, Observation pair' button. Check the boxes for metrics to calculate
     in the report.
-    
+
      <img class="my-3" src="/images/report_form.png"/>
-    
+
     After clicking submit, you will be returned to the report listing page where
     you will see the newly created report with a status of 'pending'. The Arbiter
     will process the report and then set its status to 'complete'. You may then
@@ -218,7 +218,7 @@ for details.
 {: .anchor}
 
 User, permission and role administation can be accessed by clicking the 'User
-Administration' link in the Account menu in the top right corner of the site. 
+Administration' link in the Account menu in the top right corner of the site.
     <img class="my-3" src="/images/admin_menu.png"/>
 
 

--- a/dashboard_documentation.md
+++ b/dashboard_documentation.md
@@ -19,7 +19,7 @@ on how to access the current version of the dashboard.
 Please see the [data model documentation](/datamodel/) for more details on
 how the Solar Forecast Arbiter organizes metadata (Sites, Observations, and Forecasts)
 and time series data.
-Tutorial materials are available at this [link](https://github.com/SolarArbiter/2019-Denver-Workshop).
+Tutorial materials are available in our [2019 Denver Workshop repository](https://github.com/SolarArbiter/2019-Denver-Workshop).
 
 
 Getting Started

--- a/dashboard_documentation.md
+++ b/dashboard_documentation.md
@@ -7,20 +7,25 @@ Dashboard Documentation
 =======================
 {: .anchor}
 
-This documentation will provide step-by-step examples of how to perform
+The Solar Forecast Arbiter Dashboard is a web interface for managing solar
+observation and forecast data and for evaluating solar forecast accuracy.
+This documentation provides step-by-step examples of how to perform
 common activities on the Solar Forecast Arbiter dashboard. The Content menu
-can be used to navigate between each activity. Each section will include
+can be used to navigate between each activity. Each section includes
 instructions and screenshots.
 
 Be sure to read the [Getting Started](#getting-started) section for instructions
 on how to access the current version of the dashboard.
+Please see the [data model documentation](/datamodel/) for more details on
+how the Solar Forecast Arbiter organizes metadata (Sites, Observations, and Forecasts)
+and time series data.
 
 
 Getting Started
 ---------------
 {: .anchor}
 
-The alpha release of the Solar Forecast arbiter dashboard does not support automatic
+The alpha release of the Solar Forecast Arbiter dashboard does not yet support automatic
 signup. In the meantime, you may use any of the credentials below to log in and
 explore the dashboard. You will be prompted to log in on the front page of the
 dashboard at [dashboard.solarforecastarbiter.org](https://dashboard.solarforecastarbiter.org)
@@ -48,7 +53,6 @@ Create New Site
 2. Enter the metadata for your Site. Selecting a site type of
    'Power Plant' will prompt you for additional fields.
 
-
    - *Weather station site creation form*
    <img class="my-3" src="/images/SiteForm.png"/>
 
@@ -65,7 +69,7 @@ Create New Site
 
 
 Create New Observation or Forecast
----------------------------------
+----------------------------------
 {: .anchor}
 
 To create an Observation or Forecast, an associated site must already exist (see [Create New Site](#create-new-site)).
@@ -115,7 +119,7 @@ must already exist (see [Create New Site](#create-New-site) or
 The instructions here will describe the process of
 uploading data using the dashboard.
 Uploading data may be automated using the API, see
-[https://dev-api.solarforecastarbiter.org/](https://dev-api.solarforecastarbiter.org/)
+[https://api.solarforecastarbiter.org/](https://api.solarforecastarbiter.org/)
 for detailed documentation.
 
 ### Upload Observation Data
@@ -162,7 +166,7 @@ Download Data
 The instructions here will describe the process of
 downloading data using the dashboard.
 Users may also utilize the API to download data. See the
-[API documentation](https://dev-api.solarforecastarbiter.org/)
+[API documentation](https://api.solarforecastarbiter.org/)
 for details.
 
 ### Download Observation data

--- a/data_model.md
+++ b/data_model.md
@@ -29,14 +29,14 @@ steps in order:
     parameters for a Site representing a power plant (e.g. AC capacity,
     DC capacity).
 
-2.  For each Observation,
+2.  For each Observation:
 
-  a. Define the Observation: name, variable (e.g., GHI), interval value
-     type (e.g. instantaneous or average), interval label (N/A, beginning,
-     ending), uncertainty.
+    a. Define the Observation: name, variable (e.g., GHI), interval value
+       type (e.g. instantaneous or average), interval label (N/A, beginning,
+       ending), uncertainty.
 
-	b. Upload a time series with each element in the series being a
-	   triplet of values: Time, Value, Quality Flag.
+	  b. Upload a time series with each element in the series being a
+	     triplet of values: Time, Value, Quality Flag.
 
 In this model, each of several Observations (e.g., GHI, air temperature,
 wind speed) is uploaded as a separate time series. Because each

--- a/data_model.md
+++ b/data_model.md
@@ -10,13 +10,12 @@ The goal of this document is to explain the Solar Forecast Arbiter data
 model. To keep the framework architecture simple and secure, the API
 closely follows this data model. Therefore, it is worthwhile for API
 users to understand the data model. Please see
-[dev-api.solarforecastarbiter.org](https://dev-api.solarforecastarbiter.org/)
+[api.solarforecastarbiter.org](https://api.solarforecastarbiter.org/)
 for the technical API documentation. The Dashboard should be clear
 enough that users of it do not need a complete understanding of the data
-model. The Dashboard may contain additional features and abstractions to
-expedite common use cases. See
-[solarforecastarbiter.org/dashboarddoc/](/dashboarddoc/)
-for a walkthrough of the proposed Dashboard user interface.
+model. The Dashboard contains additional features and abstractions to
+expedite common use cases. See [here](/documentation/dashboard/)
+for a walkthrough of the Dashboard user interface.
 
 Data ownership, access, and control issues will be discussed in other
 documents.

--- a/stakeholdercommittee.md
+++ b/stakeholdercommittee.md
@@ -38,3 +38,6 @@ Links to previous stakeholder committee communications are provided below.
 1. [Data exchange: Request for feedback](https://mailchi.mp/c2bf820086d5/data-exchange-feedback-request)
 1. [Data exchange: Webinar recording](https://mailchi.mp/05f35ded731e/data-exchange-feedback-request-265293?e=[UNIQID])
 1. [Data exchange: Response to feedback and revisions](https://mailchi.mp/206cda88a2ec/data-exchange-revisions)
+1. [Metrics: Request for feedback](https://mailchi.mp/a1d0a5c47c59/forecast-evaluation-metrics)
+1. [2019 Solar Forecasting 2 Workshop: Save the date](https://mailchi.mp/388eaa4867d2/doe-solar-forecasting-2-stakeholder-workshop?e=[UNIQID])
+1. [2019 Solar Forecasting 2 Workshop: Agenda](https://mailchi.mp/8066feed8d91/doe-solar-forecasting-2-stakeholder-workshop-351193?e=[UNIQID])


### PR DESCRIPTION
I was hoping to incorporate more of the tutorial material in https://github.com/SolarArbiter/2019-Denver-Workshop but didn't want to mess up the nice, clear structure that was already here. So I ended up just linking to it. We'll need to move/rename that material in the future.