### PR TITLE
metrics: correct typo in OVER definition

### DIFF
--- a/metrics.md
+++ b/metrics.md
@@ -127,7 +127,7 @@ $$ OVER = \int_{p_{\text{min}}}^{p_{\text{max}}} D_n^* dp $$
 where
 
 $$ D_n^* = \begin{cases}
-    \displaystyle D_n - V & \text{if} & D_n > V_c \\
+    \displaystyle D_n - V_c & \text{if} & D_n > V_c \\
     \displaystyle 0 & \text{if} & D_n \leq V_c
 \end{cases} $$
 

--- a/metrics.md
+++ b/metrics.md
@@ -126,7 +126,7 @@ $$ OVER = \int_{p_{\text{min}}}^{p_{\text{max}}} D_n^* dp $$
 
 where
 
-$$ D_n^* \begin{cases}
+$$ D_n^* = \begin{cases}
     \displaystyle D_n - V & \text{if} & D_n > V_c \\
     \displaystyle 0 & \text{if} & D_n \leq V_c
 \end{cases} $$


### PR DESCRIPTION
There was a typo in the OVER metric definition. Specifically, a missing equal sign in the `D_n^*` equation and a missing subscript. Note: this doesn't change the meaning of the metric.