### PR TITLE
Add NMAE and NMBE, deadband discussion to metrics page

### DIFF
--- a/_includes/metrics_sidebar.html
+++ b/_includes/metrics_sidebar.html
@@ -9,6 +9,8 @@
       <li><a href="#rmse">Root Mean Square Error (RMSE)</a></li>
       <li><a href="#s">Forecast Skill </a></li>
       <li><a href="#mape">Mean Absolute Percentage Error (MAPE)</a></li>
+      <li><a href="#nmae">Normalized Mean Absolute Error (NMAE)</a></li>
+      <li><a href="#nmbe">Normalized Mean Bias Error (NMBE)</a></li>
       <li><a href="#nrmse">Normalized Root Mean Square Error (NRMSE)</a></li>
       <li><a href="#crmse">Centered (unbiased) Root Mean Square Error (CRMSE)</a></li>
       <li><a href="#r">Pearson Correlation Coefficient</a></li>

--- a/metrics.md
+++ b/metrics.md
@@ -68,7 +68,7 @@ $$ \text{MAPE} = 100\% \cdot \frac{1}{n} \sum_{i=1}^n | \frac{F_i - O_i}{O_i} | 
 {: .anchor }
 The NMAE [%] is the normalized form of the MAE and is defined as:
 
-$$ \text{NMAE} = \frac{100\%}{\text{norm}} \frac{1}{n} \sum_{i=1}^n  \lvert F_i - O_i \rvert $$
+$$ \text{NMAE} = \frac{100\%}{\text{norm}} \cdot \frac{1}{n} \sum_{i=1}^n  \lvert F_i - O_i \rvert $$
 
 where norm is a constant upper bound on the value of the forecasted variable, e.g., 1000 W/m$$^2$$ for GHI or the nameplate AC capacity of a PV plant.
 
@@ -77,7 +77,7 @@ where norm is a constant upper bound on the value of the forecasted variable, e.
 {: .anchor }
 The NMBE [%} is the normalized form of the MBE and is defined as:
 
-$$ \text{NMBE} = \frac{100\%}{\text{norm}} \frac{1}{n} \sum_{i=1}^n (F_i - O_i) $$
+$$ \text{NMBE} = \frac{100\%}{\text{norm}} \cdot \frac{1}{n} \sum_{i=1}^n (F_i - O_i) $$
 
 where norm is a constant upper bound on the value of the forecasted variable, e.g., 1000 W/m$$^2$$ for GHI or the nameplate AC capacity of a PV plant.
 

--- a/metrics.md
+++ b/metrics.md
@@ -24,11 +24,13 @@ In the metrics below, we adopt the following nomenclature:
 
 For more information on these metrics and others, see [Zhang15](#ref-zhang15), [Wilks11](#ref-wilks11) and the references listed below.
 
-Note that for normalized metrics ([NMAE](#nmae), [NMBE](#nmbe), [NRMSE](#nrmse)), the Solar Solar Arbiter currently allows no user control over normalization via the dashboard. Instead, the Arbiter has the following behavior depending on the forecasted variable type:
+Note that for normalized metrics ([NMAE](#nmae), [NMBE](#nmbe), [NRMSE](#nrmse)), the Solar Forecast Arbiter currently allows no user control over normalization via the dashboard. Instead, the Arbiter has the following behavior depending on the forecasted variable type:
 - AC power: normalize using the AC capacity of the selected power plant
 - DC power: normalize using the DC capacity of the selected power plant
 - irradiance: no normalization; return normalized metric values as `NaN`
 - weather (e.g. wind speed): no normalization; return normalized metric values as `NaN`
+
+Additionally, the Solar Forecast Arbiter allows users to account for observation uncertainty by setting the error (forecast - observation) equal to zero for any point that is within a specified deadband, with the error unchanged for any point that lies outside the deadband. The deadband is specified as a percentage of the observation value at each time. A value of `None` indicates that no deadband was applied for that observation/forecast pair. Currently, the deadband is accounted for in the following metrics: [MAE](#mae), [MBE](#mbe), [RMSE](#rmse), [MAPE](#mape), [NMAE](#nmae), [NMBE](#nmbe), [NRMSE](#nrmse). The deadband is ignored for all other metrics.
 
 
 ### Mean Absolute Error (MAE) {#mae}

--- a/metrics.md
+++ b/metrics.md
@@ -24,6 +24,12 @@ In the metrics below, we adopt the following nomenclature:
 
 For more information on these metrics and others, see [Zhang15](#ref-zhang15), [Wilks11](#ref-wilks11) and the references listed below.
 
+Note that for normalized metrics ([NMAE](#nmae), [NMBE](#nmbe), [NRMSE](#nrmse)), the Solar Solar Arbiter currently allows no user control over normalization via the dashboard. Instead, the Arbiter has the following behavior depending on the forecasted variable type:
+- AC power: normalize using the AC capacity of the selected power plant
+- DC power: normalize using the DC capacity of the selected power plant
+- irradiance: no normalization; return normalized metric values as `NaN`
+- weather (e.g. wind speed): no normalization; return normalized metric values as `NaN`
+
 
 ### Mean Absolute Error (MAE) {#mae}
 {: .anchor }
@@ -70,7 +76,7 @@ The NMAE [%] is the normalized form of the MAE and is defined as:
 
 $$ \text{NMAE} = \frac{100\%}{\text{norm}} \cdot \frac{1}{n} \sum_{i=1}^n  \lvert F_i - O_i \rvert $$
 
-where norm is a constant upper bound on the value of the forecasted variable, e.g., 1000 W/m$$^2$$ for GHI or the nameplate AC capacity of a PV plant.
+where norm is a constant upper bound on the value of the forecasted variable, e.g., the nameplate AC (DC) capacity of a PV plant when forecasting AC (DC) power.
 
 
 ### Normalized Mean Bias Error (NMBE) {#nmbe}
@@ -79,7 +85,7 @@ The NMBE [%} is the normalized form of the MBE and is defined as:
 
 $$ \text{NMBE} = \frac{100\%}{\text{norm}} \cdot \frac{1}{n} \sum_{i=1}^n (F_i - O_i) $$
 
-where norm is a constant upper bound on the value of the forecasted variable, e.g., 1000 W/m$$^2$$ for GHI or the nameplate AC capacity of a PV plant.
+where norm is a constant upper bound on the value of the forecasted variable, e.g., the nameplate AC (DC) capacity of a PV plant when forecasting AC (DC) power.
 
 ### Normalized Root Mean Square Error (NRMSE) {#nrmse}
 {: .anchor }
@@ -87,7 +93,7 @@ The NRMSE [%] is the normalized form of the RMSE and is defined as:
 
 $$ \text{NRMSE} = \frac{100\%}{\text{norm}} \cdot \sqrt{ \frac{1}{n} \sum_{i=1}^n (F_i - O_i)^2 } $$
 
-where norm is a constant upper bound on the value of the forecasted variable, e.g., 1000 W/m$$^2$$ for GHI or the nameplate AC capacity of a PV plant.
+where norm is a constant upper bound on the value of the forecasted variable, e.g., the nameplate AC (DC) capacity of a PV plant when forecasting AC (DC) power.
 
 
 ### Centered (unbiased) Root Mean Square Error (CRMSE) {#crmse}

--- a/metrics.md
+++ b/metrics.md
@@ -64,11 +64,30 @@ The absolute percentage error is the absolute value of the difference between th
 $$ \text{MAPE} = 100\% \cdot \frac{1}{n} \sum_{i=1}^n | \frac{F_i - O_i}{O_i} | $$
 
 
+### Normalized Mean Absolute Error (NMAE) {#nmae}
+{: .anchor }
+The NMAE [%] is the normalized form of the MAE and is defined as:
+
+$$ \text{NMAE} = \frac{100\%}{\text{norm}} \frac{1}{n} \sum_{i=1}^n  \lvert F_i - O_i \rvert $$
+
+where norm is a constant upper bound on the value of the forecasted variable, e.g., 1000 W/m$$^2$$ for GHI or the nameplate AC capacity of a PV plant.
+
+
+### Normalized Mean Bias Error (NMBE) {#nmbe}
+{: .anchor }
+The NMBE [%} is the normalized form of the MBE and is defined as:
+
+$$ \text{NMBE} = \frac{100\%}{\text{norm}} \frac{1}{n} \sum_{i=1}^n (F_i - O_i) $$
+
+where norm is a constant upper bound on the value of the forecasted variable, e.g., 1000 W/m$$^2$$ for GHI or the nameplate AC capacity of a PV plant.
+
 ### Normalized Root Mean Square Error (NRMSE) {#nrmse}
 {: .anchor }
 The NRMSE [%] is the normalized form of the RMSE and is defined as:
 
-$$ \text{RMSE} = \frac{100\%}{\text{norm}} \cdot \sqrt{ \frac{1}{n} \sum_{i=1}^n (F_i - O_i)^2 } $$
+$$ \text{NRMSE} = \frac{100\%}{\text{norm}} \cdot \sqrt{ \frac{1}{n} \sum_{i=1}^n (F_i - O_i)^2 } $$
+
+where norm is a constant upper bound on the value of the forecasted variable, e.g., 1000 W/m$$^2$$ for GHI or the nameplate AC capacity of a PV plant.
 
 
 ### Centered (unbiased) Root Mean Square Error (CRMSE) {#crmse}


### PR DESCRIPTION
Resolves issue #141 by adding definitions of the normalized MAE (NMAE) and normalized MBE (NMBE) to the metrics page, including links in the sidebar menu. Also adds notes to the NMAE, NMBE, and NRMSE definitions about how the norm value is defined.