### PR TITLE
Use abbrevated event metric anchors for dashboard linking

### DIFF
--- a/_includes/metrics_sidebar.html
+++ b/_includes/metrics_sidebar.html
@@ -22,12 +22,12 @@
     </ol>
   <li><a href="#metrics-for-deterministic-event-forecasts">Metrics for Deterministic Forecast Events</li>
     <ol type="A">
-      <li><a href="#probability-of-detection-pod">Probability of Detection (POD)</a></li>
-      <li><a href="#false-alarm-ratio-far">False Alarm Ratio (FAR)</a></li>
-      <li><a href="#probability-of-false-detection-pofd">Probability of False Detection (POFD)</a></li>
-      <li><a href="#critical-success-index-csi">Critical Success Index (CSI)</a></li>
-      <li><a href="#event-bias-ebias">Event Bias (EBIAS)</a></li>
-      <li><a href="#event-accuracy-ea">Event Accuracy (EA)</a></li>
+      <li><a href="#pod">Probability of Detection (POD)</a></li>
+      <li><a href="#far">False Alarm Ratio (FAR)</a></li>
+      <li><a href="#pofd">Probability of False Detection (POFD)</a></li>
+      <li><a href="#csi">Critical Success Index (CSI)</a></li>
+      <li><a href="#ebias">Event Bias (EBIAS)</a></li>
+      <li><a href="#ea">Event Accuracy (EA)</a></li>
     </ol>
   <li><a href="#metrics-for-probablistic-forecasts">Metrics for Probablistic Forecasts</li>
     <ol type="A">

--- a/metrics.md
+++ b/metrics.md
@@ -215,42 +215,42 @@ Based on the predefined threshold, all observations or forecasts can be evaluate
 By then counting the the number of TP, FP, TN and FN values, the following metrics can be computed:
 
 
-### Probability of Detection (POD)
+### Probability of Detection (POD) {#pod}
 {: .anchor }
 The POD is the fraction of observed events correctly forecasted as events:
 
 $$ POD = \frac{TP}{TP + FN} $$
 
 
-### False Alarm Ratio (FAR)
+### False Alarm Ratio (FAR) {#far}
 {: .anchor }
 The FAR is the fraction of forecasted events that did not occur:
 
 $$ FAR = \frac{FP}{TP + FP} $$
 
 
-### Probability of False Detection (POFD)
+### Probability of False Detection (POFD) {#pofd}
 {: .anchor }
 The POFD is the fraction of observed non-events that were forecasted as events:
 
 $$ POFD = \frac{FP}{FP + TN} $$
 
 
-### Critical Success Index (CSI)
+### Critical Success Index (CSI) {#csi}
 {: .anchor }
 The CSI evaluates how well an event forecast predicts observed events, e.g., ramps in irradiance or power. THe CSI is the relative frequency of hits, i.e., how well predicted "yes" events correspond to observed "yes" events:
 
 $$ CSI = \frac{TP}{TP + FP + FN} $$
 
 
-### Event Bias (EBIAS)
+### Event Bias (EBIAS) {#ebias}
 {: .anchor }
 The EBIAS is the ratio of counts of forecast and observed events:
 
 $$ EBIAS = \frac{TP + FP}{TP + FN} $$
 
 
-### Event Accuracy (EA)
+### Event Accuracy (EA) {#ea}
 {: .anchor }
 The EA is the fraction of events that were forecasted correctly, i.e., forecast = "yes" and observed = "yes" or forecast = "no" and observed = "no":
 


### PR DESCRIPTION
closes https://github.com/SolarArbiter/solarforecastarbiter-dashboard/issues/412
Adjusts ids of headers in the event metrics section such that they can be programatically linked from the dashboard. Only thing missing in the issue is that we do not have a CRPSS section.